### PR TITLE
Changed default template to explicitly ignore error

### DIFF
--- a/basic/cmd/basic/main-tpl.go
+++ b/basic/cmd/basic/main-tpl.go
@@ -14,7 +14,7 @@ var build string
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Changed default template to explicitly ignore error. This can cause warnings by some linters.